### PR TITLE
Fix case when there is no common ancestor between commits

### DIFF
--- a/compareRels.py
+++ b/compareRels.py
@@ -59,7 +59,10 @@ def cmp_rel (url):
     v = get (url)
   except Exception as e:
     sys.stderr.write ("Could not get:" + url + ". Exception:" + str(e) + "\n")
-  print (url+';'+str(v['ahead_by'])+';'+str(v['behind_by']))
+  if 'ahead_by' in v and 'behind_by' in v:
+    print (url+';'+str(v['ahead_by'])+';'+str(v['behind_by']))
+  else:
+    sys.stderr.write ("Could not compare releases for: " + url + "; There exists no common ancestor between the two versions." + "\n")
 
 
 p2r = {}


### PR DESCRIPTION
There are few cases where the api will return that there is no common ancestor between commits. In my list of releases it was the following: https://api.github.com/repos/Onegini/cordova-plugin-onegini/compare/2.1.0...1.8.7

The propose change will print an error message to standard error when that is the case